### PR TITLE
corrected version comparison and download url

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,13 +7,12 @@ task :update do
   tags_url = 'https://api.github.com/repos/davatron5000/FitVids.js/tags'
   tags = JSON.parse(Net::HTTP.get(URI(tags_url)))
   latest_tag = tags.first
-
-  if latest_tag['name'] > Fitvids::Rails::VERSION
+  if latest_tag['name'][1..-1] > Fitvids::Rails::VERSION
     upstream_location = "/davatron5000/FitVids.js/#{latest_tag['commit']['sha']}/jquery.fitvids.js"
     file_location = File.join(File.dirname(File.absolute_path(__FILE__)), 'vendor', 'assets', 'javascripts', 'fitvids.js')
     puts "Downloading new version (#{latest_tag['name']}):"
     puts upstream_location
-    Net::HTTP.start('raw2.github.com', use_ssl: true) do |http|
+    Net::HTTP.start('rawgit.com', use_ssl: true) do |http|
       resp = http.get(upstream_location)
       File.open(file_location, 'w') { |file| file.write(resp.body) }
     end


### PR DESCRIPTION
When I ran the rake file to update from FitVids.js, it turned out it had two bugs in it.

On line 10, the comparison of version numbers does not work because the version from github is prefixed by a 'v'. I fixed this by removing the first character of the github version number.

On line 15, the file is trying to be loaded from raw2.github.com, but this returned a 'file not found error'. I suspect that this is just an old url and the correct one to use now is rawgit.com.

In doing this, I discovered your gem is actually up to date, and my original problem is caused by something else. Anyway, hopefully this is of help when you actually need to update the gem.
